### PR TITLE
fix: Add reading and energyLevel to storage whitelist

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -820,14 +820,6 @@ function saveData(silent = false) {
     if (!silent) {
         data.explicitSave = true;
         console.log('📊 Op te slaan data:', data);
-        // DEBUG: Toon wat er wordt opgeslagen (tijdelijk)
-        const debugInfo =
-            `Opslaan voor ${selectedDate}:\n` +
-            `- reading: ${data.reading}\n` +
-            `- energyLevel: ${data.energyLevel}\n` +
-            `- mood: ${data.mood}\n` +
-            `- energy-value input: "${document.getElementById('energy-value')?.value}"`;
-        alert(debugInfo);
     }
 
     // Save to storage for selected date

--- a/src/js/services/storage.js
+++ b/src/js/services/storage.js
@@ -200,6 +200,19 @@ function sanitizeTrackerData(data) {
         sanitized.alcoholCount = data.alcoholConsumed ? 1 : 0;
     }
 
+    // === READING (new field) ===
+    if (data.reading !== undefined) {
+        sanitized.reading = sanitizeBoolean(data.reading);
+    }
+
+    // === ENERGY LEVEL (new field) ===
+    if (data.energyLevel !== undefined && data.energyLevel !== null) {
+        const energyValue = sanitizeNumber(data.energyLevel, 1, 5, null);
+        if (energyValue !== null) {
+            sanitized.energyLevel = energyValue;
+        }
+    }
+
     // === MOOD (new field) ===
     if (data.mood !== undefined && data.mood !== null) {
         const moodValue = sanitizeNumber(data.mood, 1, 5, null);


### PR DESCRIPTION
## Problem
Reading and energyLevel data was being lost because the `sanitizeTrackerData` function 
in storage.js didn't have these fields in its whitelist. The sanitize function only 
passes through known fields, filtering out anything not explicitly listed.

## Solution
Added `reading` (boolean) and `energyLevel` (number 1-5) to the sanitize whitelist.

## Root Cause
When new fields were added to the UI (reading checkbox, energy picker), they were added to:
- saveData() in app.js ✅
- loadDataForDate() in app.js ✅  
- statistics calculations ✅

But NOT to sanitizeTrackerData() in storage.js, which acts as a whitelist/validation layer.

## Test
1. Open app
2. Check reading checkbox, select energy level
3. Click "Bewaar"
4. Navigate away and back - reading and energy should still be set

🤖 Generated with [Claude Code](https://claude.com/claude-code)