### PR TITLE
fix: Show edit button when any data exists

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -33,7 +33,8 @@ import {
 import {
     getSectionVisibility,
     getMissedWindows,
-    getTimeWindowLabel
+    getTimeWindowLabel,
+    hasAnyData
 } from './services/timeService.js';
 
 import { initWeightPicker } from './components/wheelPicker.js';
@@ -525,12 +526,12 @@ function updateSectionVisibility() {
         }
     }
 
-    // Show edit button if any section is complete OR if in edit mode
+    // Show edit button if any data exists OR if in edit mode
     const editBtn = document.getElementById('edit-today-btn');
     if (editBtn) {
-        const hasCompleteSection = visibility.morning.complete || visibility.evening.complete;
-        // Show if: complete section exists OR currently in edit mode
-        editBtn.classList.toggle('hidden', !hasCompleteSection && !editMode);
+        const hasData = hasAnyData(todayData);
+        // Show if: any data exists OR currently in edit mode
+        editBtn.classList.toggle('hidden', !hasData && !editMode);
         // Update button text
         editBtn.textContent = editMode ? '✓ Klaar met bewerken' : '✏️ Bewerk ingevulde secties';
     }

--- a/src/js/services/timeService.js
+++ b/src/js/services/timeService.js
@@ -105,6 +105,40 @@ export function isSectionComplete(todayData, section) {
 }
 
 /**
+ * Check of er enige betekenisvolle data is ingevuld voor vandaag
+ * (los van of secties "complete" zijn met explicitSave)
+ * @param {Object|null} todayData - Data van vandaag uit storage
+ * @returns {boolean}
+ */
+export function hasAnyData(todayData) {
+    if (!todayData || typeof todayData !== 'object') {
+        return false;
+    }
+
+    // Velden die tellen als "echte data" (niet metadata)
+    const dataFields = [
+        'sleepScore',
+        'backPain',
+        'dreamed',
+        'weight',
+        'walked',
+        'mood',
+        'waterIntake',
+        'sugarConsumed',
+        'alcoholConsumed',
+        'caffeineConsumed',
+        'reading',
+        'energyLevel'
+    ];
+
+    // Check of minstens één dataveld is ingevuld
+    return dataFields.some(field => {
+        const value = todayData[field];
+        return value !== undefined && value !== null && value !== '';
+    });
+}
+
+/**
  * Bepaal de zichtbaarheid van alle secties
  * @param {Object|null} todayData - Data van vandaag uit storage
  * @returns {Object} Visibility configuratie per sectie

--- a/tests/timeService.test.js
+++ b/tests/timeService.test.js
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { hasAnyData } from '../src/js/services/timeService.js';
+
+describe('hasAnyData', () => {
+    it('returns false for null/undefined', () => {
+        expect(hasAnyData(null)).toBe(false);
+        expect(hasAnyData(undefined)).toBe(false);
+    });
+
+    it('returns false for empty object', () => {
+        expect(hasAnyData({})).toBe(false);
+    });
+
+    it('returns false for object with only metadata', () => {
+        expect(hasAnyData({ date: '2025-12-12', timestamp: 123456789 })).toBe(false);
+        expect(hasAnyData({ explicitSave: true })).toBe(false);
+    });
+
+    it('returns true when sleepScore is set', () => {
+        expect(hasAnyData({ sleepScore: 7 })).toBe(true);
+        expect(hasAnyData({ sleepScore: 0 })).toBe(true);
+    });
+
+    it('returns true when backPain is set', () => {
+        expect(hasAnyData({ backPain: 3 })).toBe(true);
+    });
+
+    it('returns true when dreamed is set', () => {
+        expect(hasAnyData({ dreamed: true })).toBe(true);
+        expect(hasAnyData({ dreamed: false })).toBe(true);
+    });
+
+    it('returns true when weight is set', () => {
+        expect(hasAnyData({ weight: 75.5 })).toBe(true);
+    });
+
+    it('returns true when walked is set', () => {
+        expect(hasAnyData({ walked: true })).toBe(true);
+        expect(hasAnyData({ walked: false })).toBe(true);
+    });
+
+    it('returns true when mood is set', () => {
+        expect(hasAnyData({ mood: 'good' })).toBe(true);
+    });
+
+    it('returns true when waterIntake is set', () => {
+        expect(hasAnyData({ waterIntake: 5 })).toBe(true);
+        expect(hasAnyData({ waterIntake: 0 })).toBe(true);
+    });
+
+    it('returns true when consumption fields are set', () => {
+        expect(hasAnyData({ sugarConsumed: false })).toBe(true);
+        expect(hasAnyData({ alcoholConsumed: true })).toBe(true);
+        expect(hasAnyData({ caffeineConsumed: false })).toBe(true);
+    });
+
+    it('returns true when reading is set', () => {
+        expect(hasAnyData({ reading: true })).toBe(true);
+    });
+
+    it('returns true when energyLevel is set', () => {
+        expect(hasAnyData({ energyLevel: 7 })).toBe(true);
+    });
+
+    it('returns false for empty string values', () => {
+        expect(hasAnyData({ sleepScore: '' })).toBe(false);
+        expect(hasAnyData({ mood: '' })).toBe(false);
+    });
+
+    it('returns true with mixed data and metadata', () => {
+        expect(
+            hasAnyData({
+                date: '2025-12-12',
+                sleepScore: 8,
+                explicitSave: false
+            })
+        ).toBe(true);
+    });
+});


### PR DESCRIPTION
## Summary
- Fix bug where "Bewerk ingevulde secties" button was not showing
- Button now appears when **any** data is saved, not only when sections are "complete"
- Added `hasAnyData()` helper function with comprehensive tests

## Problem
The edit button required `isSectionComplete()` to be true, which checks for:
1. All required fields filled
2. `explicitSave === true` flag

This caused the button to disappear when:
- Data was saved via autoSave (without clicking "Bewaar")
- The `explicitSave` flag was missing from older data

## Solution
New `hasAnyData()` function checks if any meaningful data field is set (sleepScore, backPain, weight, mood, etc.), regardless of completeness or save method.

## Test plan
- [x] `npm run lint` passes
- [x] `npm test` passes (66 tests, +15 new)
- [x] `npm run build` passes
- [ ] Manual test: verify edit button appears after entering any data

Fixes #67

🤖 Generated with [Claude Code](https://claude.com/claude-code)