### PR TITLE
feat: feedback link in settings

### DIFF
--- a/.github/ISSUE_TEMPLATE/feedback.yml
+++ b/.github/ISSUE_TEMPLATE/feedback.yml
@@ -1,0 +1,49 @@
+name: Feedback
+description: Deel je feedback, ideeën of meld een probleem
+title: "Feedback: "
+labels: ["feedback", "status: needs-review"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Bedankt dat je feedback wilt geven! Elk idee of probleem is welkom.
+
+  - type: dropdown
+    id: type
+    attributes:
+      label: Wat voor feedback heb je?
+      options:
+        - Iets werkt niet goed
+        - Idee voor verbetering
+        - Nieuwe functie gewenst
+        - Overig
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Vertel meer
+      description: Beschrijf wat je hebt ervaren of wat je graag zou willen
+      placeholder: |
+        Bijvoorbeeld:
+        - "De app slaat mijn data niet op"
+        - "Het zou fijn zijn als ik X kon doen"
+        - "Ik snap niet hoe Y werkt"
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshot
+    attributes:
+      label: Screenshot (optioneel)
+      description: Een plaatje zegt soms meer dan woorden
+      placeholder: Sleep een afbeelding hierheen
+
+  - type: checkboxes
+    id: contact
+    attributes:
+      label: Mag ik contact opnemen?
+      options:
+        - label: Ja, je mag reageren op deze feedback
+          required: false

--- a/src/index.html
+++ b/src/index.html
@@ -989,6 +989,20 @@
                     </a>
                 </div>
 
+                <!-- Feedback -->
+                <div class="settings-card">
+                    <h3>Feedback</h3>
+                    <p class="settings-desc">Werkt iets niet? Heb je een idee? Laat het weten!</p>
+                    <a
+                        href="https://github.com/mdubbelm/habittracker/issues/new?template=feedback.yml"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        class="btn-secondary feedback-link"
+                    >
+                        💬 Feedback geven
+                    </a>
+                </div>
+
                 <!-- About / Version -->
                 <div class="settings-card settings-card-muted">
                     <h3>Over Health Tracker</h3>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1424,6 +1424,14 @@ button:focus-visible {
     border: none;
 }
 
+/* Feedback Link */
+.feedback-link {
+    display: block;
+    text-align: center;
+    text-decoration: none;
+    margin-top: var(--spacing-sm);
+}
+
 .version-info {
     display: flex;
     flex-direction: column;


### PR DESCRIPTION
## Summary
- Adds a simple feedback form template for non-technical users
- Adds "Feedback geven" button in Settings view
- Opens GitHub issue form with user-friendly template

## Test plan
- [ ] Open Settings in the app
- [ ] Verify "Feedback" card is visible
- [ ] Click "Feedback geven" button
- [ ] Verify GitHub issue form opens with feedback template

🤖 Generated with [Claude Code](https://claude.com/claude-code)