### PR TITLE
feat: Calendar overview met gekleurde score-bolletjes (#73)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,7 @@ workbox-*.js.map
 # Misc
 .cache/
 .parcel-cache/
+
+# Local symlinks (workspace-level agents)
+.claude/agents
+.claude/knowledge

--- a/src/index.html
+++ b/src/index.html
@@ -812,10 +812,103 @@
                 </div>
             </section>
 
-            <!-- History View (placeholder) -->
+            <!-- History View - Calendar Overview -->
             <section id="history-view" class="view">
                 <h2>Geschiedenis</h2>
-                <p>Binnenkort beschikbaar...</p>
+
+                <!-- Calendar Navigation -->
+                <div class="calendar-nav">
+                    <button id="prev-month" class="calendar-nav-btn" aria-label="Vorige maand">
+                        <svg
+                            width="20"
+                            height="20"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                        >
+                            <path d="M15 18l-6-6 6-6" />
+                        </svg>
+                    </button>
+                    <h3 id="calendar-month-year" class="calendar-title">december 2025</h3>
+                    <button id="next-month" class="calendar-nav-btn" aria-label="Volgende maand">
+                        <svg
+                            width="20"
+                            height="20"
+                            viewBox="0 0 24 24"
+                            fill="none"
+                            stroke="currentColor"
+                            stroke-width="2"
+                        >
+                            <path d="M9 18l6-6-6-6" />
+                        </svg>
+                    </button>
+                </div>
+
+                <!-- Calendar Grid -->
+                <div class="calendar-container">
+                    <!-- Weekday Headers -->
+                    <div class="calendar-weekdays">
+                        <span>ma</span>
+                        <span>di</span>
+                        <span>wo</span>
+                        <span>do</span>
+                        <span>vr</span>
+                        <span>za</span>
+                        <span>zo</span>
+                    </div>
+
+                    <!-- Calendar Days Grid -->
+                    <div
+                        id="calendar-grid"
+                        class="calendar-grid"
+                        role="grid"
+                        aria-label="Kalender met dagscores"
+                    >
+                        <!-- Days will be rendered by JavaScript -->
+                    </div>
+                </div>
+
+                <!-- Legend -->
+                <div class="calendar-legend">
+                    <div class="legend-item">
+                        <span class="legend-dot" style="background-color: #6b8e5e"></span>
+                        <span>Uitstekend</span>
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-dot" style="background-color: #8aa67c"></span>
+                        <span>Goed</span>
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-dot" style="background-color: #eab308"></span>
+                        <span>Matig</span>
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-dot" style="background-color: #f59e0b"></span>
+                        <span>Let op</span>
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-dot" style="background-color: #ef4444"></span>
+                        <span>Aandacht</span>
+                    </div>
+                    <div class="legend-item">
+                        <span class="legend-dot legend-dot-empty"></span>
+                        <span>Geen data</span>
+                    </div>
+                </div>
+
+                <!-- Day Detail (shown when tapping a day) -->
+                <div id="day-detail" class="day-detail hidden">
+                    <div class="day-detail-header">
+                        <h4 id="day-detail-date"></h4>
+                        <button id="close-day-detail" class="day-detail-close" aria-label="Sluiten">
+                            ×
+                        </button>
+                    </div>
+                    <div id="day-detail-content" class="day-detail-content">
+                        <!-- Day details will be rendered by JavaScript -->
+                    </div>
+                </div>
             </section>
 
             <!-- Settings View -->

--- a/src/js/services/calendarService.js
+++ b/src/js/services/calendarService.js
@@ -1,0 +1,182 @@
+/**
+ * Calendar Service
+ *
+ * Provides calendar utilities for the history overview
+ * Generates month grids with health score data
+ *
+ * @module services/calendarService
+ */
+
+import { calculateHealthScore, getScoreColor } from './healthScore.js';
+
+/**
+ * Get number of days in a month
+ * @param {number} year - Full year (e.g., 2025)
+ * @param {number} month - Month (0-11)
+ * @returns {number} Number of days
+ */
+export function getDaysInMonth(year, month) {
+    return new Date(year, month + 1, 0).getDate();
+}
+
+/**
+ * Get the weekday of the first day of a month (Monday = 0)
+ * @param {number} year - Full year
+ * @param {number} month - Month (0-11)
+ * @returns {number} Weekday (0 = Monday, 6 = Sunday)
+ */
+export function getFirstDayOfMonth(year, month) {
+    const day = new Date(year, month, 1).getDay();
+    // Convert from Sunday = 0 to Monday = 0
+    return day === 0 ? 6 : day - 1;
+}
+
+/**
+ * Format month name in Dutch
+ * @param {number} month - Month (0-11)
+ * @returns {string} Dutch month name
+ */
+export function getMonthName(month) {
+    const months = [
+        'januari',
+        'februari',
+        'maart',
+        'april',
+        'mei',
+        'juni',
+        'juli',
+        'augustus',
+        'september',
+        'oktober',
+        'november',
+        'december'
+    ];
+    return months[month];
+}
+
+/**
+ * Format date as ISO string (YYYY-MM-DD)
+ * @param {number} year - Full year
+ * @param {number} month - Month (0-11)
+ * @param {number} day - Day of month
+ * @returns {string} ISO date string
+ */
+export function formatDateISO(year, month, day) {
+    const m = String(month + 1).padStart(2, '0');
+    const d = String(day).padStart(2, '0');
+    return `${year}-${m}-${d}`;
+}
+
+/**
+ * Check if a date is today
+ * @param {number} year - Full year
+ * @param {number} month - Month (0-11)
+ * @param {number} day - Day of month
+ * @returns {boolean} True if date is today
+ */
+export function isToday(year, month, day) {
+    const today = new Date();
+    return today.getFullYear() === year && today.getMonth() === month && today.getDate() === day;
+}
+
+/**
+ * Check if a date is in the future
+ * @param {number} year - Full year
+ * @param {number} month - Month (0-11)
+ * @param {number} day - Day of month
+ * @returns {boolean} True if date is in the future
+ */
+export function isFuture(year, month, day) {
+    const date = new Date(year, month, day);
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    return date > today;
+}
+
+/**
+ * Generate calendar data for a month
+ * @param {number} year - Full year
+ * @param {number} month - Month (0-11)
+ * @param {Object} trackerData - All tracker data (keyed by ISO date)
+ * @returns {Array} Array of week arrays, each containing day objects
+ */
+export function generateCalendarMonth(year, month, trackerData = {}) {
+    const daysInMonth = getDaysInMonth(year, month);
+    const firstDay = getFirstDayOfMonth(year, month);
+
+    const weeks = [];
+    let currentWeek = [];
+
+    // Add empty cells for days before the first of the month
+    for (let i = 0; i < firstDay; i++) {
+        currentWeek.push(null);
+    }
+
+    // Add days of the month
+    for (let day = 1; day <= daysInMonth; day++) {
+        const dateStr = formatDateISO(year, month, day);
+        const dayData = trackerData[dateStr] || null;
+        const score = dayData ? calculateHealthScore(dayData) : null;
+        const future = isFuture(year, month, day);
+
+        currentWeek.push({
+            day,
+            date: dateStr,
+            score,
+            color: future ? null : score !== null ? getScoreColor(score) : '#d1cbc3',
+            isToday: isToday(year, month, day),
+            isFuture: future,
+            hasData: dayData !== null
+        });
+
+        // Start a new week after Sunday
+        if (currentWeek.length === 7) {
+            weeks.push(currentWeek);
+            currentWeek = [];
+        }
+    }
+
+    // Fill the last week with empty cells
+    while (currentWeek.length > 0 && currentWeek.length < 7) {
+        currentWeek.push(null);
+    }
+    if (currentWeek.length > 0) {
+        weeks.push(currentWeek);
+    }
+
+    return weeks;
+}
+
+/**
+ * Get previous month
+ * @param {number} year - Full year
+ * @param {number} month - Month (0-11)
+ * @returns {Object} { year, month } of previous month
+ */
+export function getPreviousMonth(year, month) {
+    if (month === 0) {
+        return { year: year - 1, month: 11 };
+    }
+    return { year, month: month - 1 };
+}
+
+/**
+ * Get next month
+ * @param {number} year - Full year
+ * @param {number} month - Month (0-11)
+ * @returns {Object} { year, month } of next month
+ */
+export function getNextMonth(year, month) {
+    if (month === 11) {
+        return { year: year + 1, month: 0 };
+    }
+    return { year, month: month + 1 };
+}
+
+/**
+ * Get weekday headers in Dutch (short)
+ * @returns {Array} Array of weekday abbreviations
+ */
+export function getWeekdayHeaders() {
+    return ['ma', 'di', 'wo', 'do', 'vr', 'za', 'zo'];
+}

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2951,3 +2951,331 @@ a:focus-visible,
     outline: 2px solid var(--color-primary);
     outline-offset: 2px;
 }
+
+/* ============================================
+   CALENDAR (HISTORY VIEW)
+   ============================================ */
+
+/* Calendar Navigation */
+.calendar-nav {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: var(--spacing-md);
+    padding: 0 var(--spacing-xs);
+}
+
+.calendar-nav-btn {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border: none;
+    border-radius: var(--radius-full);
+    background: var(--color-gray-100);
+    color: var(--text-primary);
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+}
+
+.calendar-nav-btn:hover {
+    background: var(--color-gray-200);
+}
+
+.calendar-nav-btn:active {
+    background: var(--color-gray-300);
+}
+
+.calendar-title {
+    font-size: 1.125rem;
+    font-weight: 600;
+    color: var(--text-primary);
+    text-transform: capitalize;
+}
+
+/* Calendar Container */
+.calendar-container {
+    background: var(--bg-card);
+    border-radius: var(--radius-lg);
+    padding: var(--spacing-md);
+    border: var(--border-subtle);
+}
+
+/* Weekday Headers */
+.calendar-weekdays {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: var(--spacing-xs);
+    margin-bottom: var(--spacing-sm);
+    text-align: center;
+}
+
+.calendar-weekdays span {
+    font-size: 0.75rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    text-transform: uppercase;
+    padding: var(--spacing-xs) 0;
+}
+
+/* Calendar Grid */
+.calendar-grid {
+    display: grid;
+    grid-template-columns: repeat(7, 1fr);
+    gap: var(--spacing-xs);
+}
+
+/* Calendar Day Cell */
+.calendar-day {
+    position: relative;
+    aspect-ratio: 1;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    border-radius: var(--radius-md);
+    cursor: pointer;
+    transition:
+        transform 0.1s ease,
+        background-color 0.15s ease;
+    background: transparent;
+    border: none;
+    padding: 0;
+}
+
+.calendar-day:hover:not(.calendar-day--empty):not(.calendar-day--future) {
+    background: var(--color-gray-100);
+}
+
+.calendar-day:active:not(.calendar-day--empty):not(.calendar-day--future) {
+    transform: scale(0.95);
+}
+
+/* Day Number */
+.calendar-day__number {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--text-primary);
+    margin-bottom: 2px;
+}
+
+/* Score Dot */
+.calendar-day__dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+    transition: transform 0.15s ease;
+}
+
+.calendar-day:hover .calendar-day__dot {
+    transform: scale(1.2);
+}
+
+/* Empty Day (days outside current month) */
+.calendar-day--empty {
+    cursor: default;
+}
+
+/* Future Day */
+.calendar-day--future {
+    cursor: default;
+}
+
+.calendar-day--future .calendar-day__number {
+    color: var(--text-muted);
+}
+
+/* Today Indicator */
+.calendar-day--today {
+    background: var(--color-gray-100);
+}
+
+.calendar-day--today .calendar-day__number {
+    font-weight: 700;
+    color: var(--color-primary);
+}
+
+.calendar-day--today::after {
+    content: '';
+    position: absolute;
+    bottom: 2px;
+    width: 4px;
+    height: 4px;
+    border-radius: 50%;
+    background: var(--color-primary);
+}
+
+/* Calendar Legend */
+.calendar-legend {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--spacing-sm) var(--spacing-md);
+    margin-top: var(--spacing-lg);
+    padding: var(--spacing-md);
+    background: var(--bg-card);
+    border-radius: var(--radius-lg);
+    border: var(--border-subtle);
+}
+
+.legend-item {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+}
+
+.legend-dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.legend-dot-empty {
+    background: var(--color-gray-200);
+    border: 1px dashed var(--color-gray-300);
+}
+
+.legend-item span:last-child {
+    font-size: 0.75rem;
+    color: var(--text-secondary);
+}
+
+/* Day Detail Panel */
+.day-detail {
+    margin-top: var(--spacing-lg);
+    padding: var(--spacing-md);
+    background: var(--bg-card);
+    border-radius: var(--radius-lg);
+    border: var(--border-subtle);
+    animation: slideUp 0.2s ease;
+}
+
+@keyframes slideUp {
+    from {
+        opacity: 0;
+        transform: translateY(8px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.day-detail.hidden {
+    display: none;
+}
+
+.day-detail-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin-bottom: var(--spacing-md);
+    padding-bottom: var(--spacing-sm);
+    border-bottom: var(--border-subtle);
+}
+
+.day-detail-header h4 {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+.day-detail-close {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 32px;
+    height: 32px;
+    border: none;
+    border-radius: var(--radius-full);
+    background: var(--color-gray-100);
+    color: var(--text-secondary);
+    font-size: 1.25rem;
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+}
+
+.day-detail-close:hover {
+    background: var(--color-gray-200);
+}
+
+.day-detail-content {
+    display: flex;
+    flex-direction: column;
+    gap: var(--spacing-sm);
+}
+
+.day-detail-score {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-sm);
+    padding: var(--spacing-sm);
+    background: var(--color-gray-50);
+    border-radius: var(--radius-md);
+}
+
+.day-detail-score__value {
+    font-size: 1.5rem;
+    font-weight: 700;
+}
+
+.day-detail-score__label {
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+}
+
+.day-detail-metrics {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: var(--spacing-xs);
+}
+
+.day-detail-metric {
+    display: flex;
+    align-items: center;
+    gap: var(--spacing-xs);
+    padding: var(--spacing-xs) var(--spacing-sm);
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+}
+
+.day-detail-metric__icon {
+    font-size: 1rem;
+}
+
+.day-detail-empty {
+    text-align: center;
+    padding: var(--spacing-lg);
+    color: var(--text-muted);
+}
+
+/* Responsive: Larger screens */
+@media (min-width: 768px) {
+    .calendar-container {
+        max-width: 500px;
+        margin: 0 auto;
+    }
+
+    .calendar-legend {
+        max-width: 500px;
+        margin-left: auto;
+        margin-right: auto;
+        margin-top: var(--spacing-lg);
+    }
+
+    .day-detail {
+        max-width: 500px;
+        margin-left: auto;
+        margin-right: auto;
+    }
+
+    .calendar-day__number {
+        font-size: 1rem;
+    }
+
+    .calendar-day__dot {
+        width: 12px;
+        height: 12px;
+    }
+}

--- a/tests/calendarService.test.js
+++ b/tests/calendarService.test.js
@@ -1,0 +1,240 @@
+/**
+ * Calendar Service Tests
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+    getDaysInMonth,
+    getFirstDayOfMonth,
+    getMonthName,
+    formatDateISO,
+    isToday,
+    isFuture,
+    generateCalendarMonth,
+    getPreviousMonth,
+    getNextMonth,
+    getWeekdayHeaders
+} from '../src/js/services/calendarService.js';
+
+describe('calendarService', () => {
+    describe('getDaysInMonth', () => {
+        it('returns 31 for January', () => {
+            expect(getDaysInMonth(2025, 0)).toBe(31);
+        });
+
+        it('returns 28 for February in non-leap year', () => {
+            expect(getDaysInMonth(2025, 1)).toBe(28);
+        });
+
+        it('returns 29 for February in leap year', () => {
+            expect(getDaysInMonth(2024, 1)).toBe(29);
+        });
+
+        it('returns 30 for April', () => {
+            expect(getDaysInMonth(2025, 3)).toBe(30);
+        });
+
+        it('returns 31 for December', () => {
+            expect(getDaysInMonth(2025, 11)).toBe(31);
+        });
+    });
+
+    describe('getFirstDayOfMonth', () => {
+        it('returns correct weekday for December 2025 (Monday = 0)', () => {
+            // December 1, 2025 is a Monday
+            expect(getFirstDayOfMonth(2025, 11)).toBe(0);
+        });
+
+        it('returns correct weekday for January 2025', () => {
+            // January 1, 2025 is a Wednesday
+            expect(getFirstDayOfMonth(2025, 0)).toBe(2);
+        });
+
+        it('handles Sunday correctly (returns 6)', () => {
+            // June 1, 2025 is a Sunday
+            expect(getFirstDayOfMonth(2025, 5)).toBe(6);
+        });
+    });
+
+    describe('getMonthName', () => {
+        it('returns Dutch month names', () => {
+            expect(getMonthName(0)).toBe('januari');
+            expect(getMonthName(5)).toBe('juni');
+            expect(getMonthName(11)).toBe('december');
+        });
+    });
+
+    describe('formatDateISO', () => {
+        it('formats date correctly', () => {
+            expect(formatDateISO(2025, 0, 1)).toBe('2025-01-01');
+            expect(formatDateISO(2025, 11, 31)).toBe('2025-12-31');
+        });
+
+        it('pads single digit months and days', () => {
+            expect(formatDateISO(2025, 0, 5)).toBe('2025-01-05');
+            expect(formatDateISO(2025, 8, 9)).toBe('2025-09-09');
+        });
+    });
+
+    describe('isToday', () => {
+        it('returns true for today', () => {
+            const now = new Date();
+            expect(isToday(now.getFullYear(), now.getMonth(), now.getDate())).toBe(true);
+        });
+
+        it('returns false for yesterday', () => {
+            const yesterday = new Date();
+            yesterday.setDate(yesterday.getDate() - 1);
+            expect(isToday(yesterday.getFullYear(), yesterday.getMonth(), yesterday.getDate())).toBe(
+                false
+            );
+        });
+
+        it('returns false for tomorrow', () => {
+            const tomorrow = new Date();
+            tomorrow.setDate(tomorrow.getDate() + 1);
+            expect(isToday(tomorrow.getFullYear(), tomorrow.getMonth(), tomorrow.getDate())).toBe(
+                false
+            );
+        });
+    });
+
+    describe('isFuture', () => {
+        it('returns true for tomorrow', () => {
+            const tomorrow = new Date();
+            tomorrow.setDate(tomorrow.getDate() + 1);
+            expect(isFuture(tomorrow.getFullYear(), tomorrow.getMonth(), tomorrow.getDate())).toBe(
+                true
+            );
+        });
+
+        it('returns false for today', () => {
+            const now = new Date();
+            expect(isFuture(now.getFullYear(), now.getMonth(), now.getDate())).toBe(false);
+        });
+
+        it('returns false for yesterday', () => {
+            const yesterday = new Date();
+            yesterday.setDate(yesterday.getDate() - 1);
+            expect(
+                isFuture(yesterday.getFullYear(), yesterday.getMonth(), yesterday.getDate())
+            ).toBe(false);
+        });
+
+        it('returns true for next year', () => {
+            const nextYear = new Date();
+            nextYear.setFullYear(nextYear.getFullYear() + 1);
+            expect(isFuture(nextYear.getFullYear(), nextYear.getMonth(), nextYear.getDate())).toBe(
+                true
+            );
+        });
+    });
+
+    describe('getPreviousMonth', () => {
+        it('returns previous month in same year', () => {
+            expect(getPreviousMonth(2025, 5)).toEqual({ year: 2025, month: 4 });
+        });
+
+        it('wraps to December of previous year', () => {
+            expect(getPreviousMonth(2025, 0)).toEqual({ year: 2024, month: 11 });
+        });
+    });
+
+    describe('getNextMonth', () => {
+        it('returns next month in same year', () => {
+            expect(getNextMonth(2025, 5)).toEqual({ year: 2025, month: 6 });
+        });
+
+        it('wraps to January of next year', () => {
+            expect(getNextMonth(2025, 11)).toEqual({ year: 2026, month: 0 });
+        });
+    });
+
+    describe('getWeekdayHeaders', () => {
+        it('returns Dutch weekday abbreviations starting with Monday', () => {
+            const headers = getWeekdayHeaders();
+            expect(headers).toEqual(['ma', 'di', 'wo', 'do', 'vr', 'za', 'zo']);
+        });
+    });
+
+    describe('generateCalendarMonth', () => {
+        it('generates correct structure for December 2025', () => {
+            const weeks = generateCalendarMonth(2025, 11, {});
+
+            // December 2025 has 5 weeks in calendar view
+            expect(weeks.length).toBeGreaterThanOrEqual(4);
+            expect(weeks.length).toBeLessThanOrEqual(6);
+
+            // First day (Monday Dec 1) should be first in first week
+            expect(weeks[0][0].day).toBe(1);
+            expect(weeks[0][0].date).toBe('2025-12-01');
+        });
+
+        it('includes empty cells for days before month starts', () => {
+            // January 2025 starts on Wednesday (index 2)
+            const weeks = generateCalendarMonth(2025, 0, {});
+
+            // First two cells should be null
+            expect(weeks[0][0]).toBeNull();
+            expect(weeks[0][1]).toBeNull();
+            expect(weeks[0][2].day).toBe(1);
+        });
+
+        it('calculates scores for days with data', () => {
+            const trackerData = {
+                '2025-12-01': {
+                    sleepScore: 8,
+                    waterIntake: 8,
+                    walked: true
+                }
+            };
+
+            const weeks = generateCalendarMonth(2025, 11, trackerData);
+            const dec1 = weeks[0][0];
+
+            expect(dec1.hasData).toBe(true);
+            expect(dec1.score).toBeGreaterThan(0);
+            expect(dec1.color).toBeDefined();
+        });
+
+        it('marks days without data correctly', () => {
+            const weeks = generateCalendarMonth(2025, 11, {});
+            const dec1 = weeks[0][0];
+
+            expect(dec1.hasData).toBe(false);
+            expect(dec1.score).toBeNull();
+        });
+
+        it('marks today correctly', () => {
+            const today = new Date();
+            const weeks = generateCalendarMonth(today.getFullYear(), today.getMonth(), {});
+
+            // Find today in the calendar
+            let foundToday = false;
+            weeks.forEach(week => {
+                week.forEach(day => {
+                    if (day && day.isToday) {
+                        expect(day.day).toBe(today.getDate());
+                        foundToday = true;
+                    }
+                });
+            });
+
+            expect(foundToday).toBe(true);
+        });
+
+        it('marks future days correctly', () => {
+            const today = new Date();
+            const weeks = generateCalendarMonth(today.getFullYear(), today.getMonth(), {});
+
+            // Future days should have isFuture: true
+            weeks.forEach(week => {
+                week.forEach(day => {
+                    if (day && day.day > today.getDate() && !day.isToday) {
+                        expect(day.isFuture).toBe(true);
+                        expect(day.color).toBeNull();
+                    }
+                });
+            });
+        });
+    });
+});


### PR DESCRIPTION
## Summary
- Kalender toegevoegd aan history-view met gekleurde bolletjes per dag
- Maandnavigatie (vorige/volgende)
- Tap op dag toont score details
- Legenda voor kleurbetekenissen

## Screenshots
De kalender toont:
- 🟢 Groen: Score 85-100% (Uitstekend)
- 🟡 Geel/Groen: Score 70-84% (Goed)
- 🟡 Geel: Score 50-69% (Matig)
- 🟠 Oranje: Score 30-49% (Let op)
- 🔴 Rood: Score <30% (Aandacht nodig)
- ⚪ Grijs: Geen data

## Changes
- `src/js/services/calendarService.js` - Nieuwe service voor kalenderlogica
- `src/js/app.js` - Calendar rendering en interactie
- `src/index.html` - History view HTML structuur
- `src/styles/main.css` - Calendar styling
- `tests/calendarService.test.js` - 29 nieuwe tests

## Test plan
- [ ] Open app, ga naar Geschiedenis tab
- [ ] Kalender toont huidige maand
- [ ] Navigeer naar vorige/volgende maand
- [ ] Tap op dag met data → toont details
- [ ] Tap op dag zonder data → toont "Geen data"
- [ ] Kleuren kloppen met scores
- [ ] Vandaag is gemarkeerd

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)