### PR TITLE
refactor: Vereenvoudig kalender (alleen bolletjes)

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -869,45 +869,10 @@
                     </div>
                 </div>
 
-                <!-- Legend -->
-                <div class="calendar-legend">
-                    <div class="legend-item">
-                        <span class="legend-dot" style="background-color: #6b8e5e"></span>
-                        <span>Uitstekend</span>
-                    </div>
-                    <div class="legend-item">
-                        <span class="legend-dot" style="background-color: #8aa67c"></span>
-                        <span>Goed</span>
-                    </div>
-                    <div class="legend-item">
-                        <span class="legend-dot" style="background-color: #eab308"></span>
-                        <span>Matig</span>
-                    </div>
-                    <div class="legend-item">
-                        <span class="legend-dot" style="background-color: #f59e0b"></span>
-                        <span>Let op</span>
-                    </div>
-                    <div class="legend-item">
-                        <span class="legend-dot" style="background-color: #ef4444"></span>
-                        <span>Aandacht</span>
-                    </div>
-                    <div class="legend-item">
-                        <span class="legend-dot legend-dot-empty"></span>
-                        <span>Geen data</span>
-                    </div>
-                </div>
-
-                <!-- Day Detail (shown when tapping a day) -->
-                <div id="day-detail" class="day-detail hidden">
-                    <div class="day-detail-header">
-                        <h4 id="day-detail-date"></h4>
-                        <button id="close-day-detail" class="day-detail-close" aria-label="Sluiten">
-                            ×
-                        </button>
-                    </div>
-                    <div id="day-detail-content" class="day-detail-content">
-                        <!-- Day details will be rendered by JavaScript -->
-                    </div>
+                <!-- Day Detail (compact tooltip, shown when tapping a day) -->
+                <div id="day-detail" class="day-detail-compact hidden">
+                    <span id="day-detail-date" class="day-detail-compact__date"></span>
+                    <span id="day-detail-score" class="day-detail-compact__score"></span>
                 </div>
             </section>
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -1288,7 +1288,6 @@ function initCalendar() {
     // Navigation buttons
     const prevBtn = document.getElementById('prev-month');
     const nextBtn = document.getElementById('next-month');
-    const closeDetailBtn = document.getElementById('close-day-detail');
 
     if (prevBtn) {
         prevBtn.addEventListener('click', () => {
@@ -1308,10 +1307,6 @@ function initCalendar() {
             renderCalendar();
             hideDayDetail();
         });
-    }
-
-    if (closeDetailBtn) {
-        closeDetailBtn.addEventListener('click', hideDayDetail);
     }
 
     // Initial render
@@ -1392,76 +1387,32 @@ function renderCalendar() {
 }
 
 /**
- * Show day detail panel
+ * Show compact day detail (date + score only)
  * @param {string} dateStr - ISO date string
  * @param {Object|null} data - Day data or null if no data
  */
 function showDayDetail(dateStr, data) {
     const detailEl = document.getElementById('day-detail');
     const dateEl = document.getElementById('day-detail-date');
-    const contentEl = document.getElementById('day-detail-content');
+    const scoreEl = document.getElementById('day-detail-score');
 
-    if (!detailEl || !dateEl || !contentEl) {
+    if (!detailEl || !dateEl || !scoreEl) {
         return;
     }
 
-    // Format date for display
+    // Format date for display (short format)
     const [year, month, day] = dateStr.split('-');
     const dateObj = new Date(year, month - 1, day);
-    const options = { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' };
-    dateEl.textContent = dateObj.toLocaleDateString('nl-NL', options);
+    dateEl.textContent = dateObj.toLocaleDateString('nl-NL', { day: 'numeric', month: 'short' });
 
     if (!data) {
-        contentEl.innerHTML = `
-            <div class="day-detail-empty">
-                <p>Geen data voor deze dag</p>
-            </div>
-        `;
+        scoreEl.textContent = '—';
+        scoreEl.style.color = 'var(--text-muted)';
     } else {
         const score = calculateHealthScore(data);
         const color = getScoreColor(score);
-
-        // Build metrics list
-        const metrics = [];
-
-        if (data.sleepScore !== undefined) {
-            metrics.push({ icon: '😴', label: `Slaap: ${data.sleepScore}/10` });
-        }
-        if (data.backPain !== undefined) {
-            metrics.push({ icon: '🔥', label: `Pijn: ${data.backPain}/10` });
-        }
-        if (data.waterIntake !== undefined) {
-            metrics.push({ icon: '💧', label: `Water: ${data.waterIntake} glazen` });
-        }
-        if (data.walked !== undefined) {
-            metrics.push({ icon: '🚶', label: data.walked ? 'Gewandeld' : 'Niet gewandeld' });
-        }
-        if (data.reading !== undefined) {
-            metrics.push({ icon: '📖', label: data.reading ? 'Gelezen' : 'Niet gelezen' });
-        }
-        if (data.mood !== undefined) {
-            const moodLabels = ['', 'Slecht', 'Matig', 'Oké', 'Goed', 'Geweldig'];
-            metrics.push({ icon: '😊', label: `Stemming: ${moodLabels[data.mood] || ''}` });
-        }
-        if (data.energyLevel !== undefined) {
-            metrics.push({ icon: '⚡', label: `Energie: ${data.energyLevel}/5` });
-        }
-
-        contentEl.innerHTML = `
-            <div class="day-detail-score">
-                <span class="day-detail-score__value" style="color: ${color}">${score}%</span>
-                <span class="day-detail-score__label">Health Score</span>
-            </div>
-            ${
-                metrics.length > 0
-                    ? `
-            <div class="day-detail-metrics">
-                ${metrics.map(m => `<div class="day-detail-metric"><span class="day-detail-metric__icon">${m.icon}</span><span>${m.label}</span></div>`).join('')}
-            </div>
-            `
-                    : ''
-            }
-        `;
+        scoreEl.textContent = `${score}%`;
+        scoreEl.style.color = color;
     }
 
     // Show panel

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3106,147 +3106,41 @@ a:focus-visible,
     background: var(--color-primary);
 }
 
-/* Calendar Legend */
-.calendar-legend {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--spacing-sm) var(--spacing-md);
-    margin-top: var(--spacing-lg);
-    padding: var(--spacing-md);
-    background: var(--bg-card);
-    border-radius: var(--radius-lg);
-    border: var(--border-subtle);
-}
-
-.legend-item {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-xs);
-}
-
-.legend-dot {
-    width: 12px;
-    height: 12px;
-    border-radius: 50%;
-    flex-shrink: 0;
-}
-
-.legend-dot-empty {
-    background: var(--color-gray-200);
-    border: 1px dashed var(--color-gray-300);
-}
-
-.legend-item span:last-child {
-    font-size: 0.75rem;
-    color: var(--text-secondary);
-}
-
-/* Day Detail Panel */
-.day-detail {
-    margin-top: var(--spacing-lg);
-    padding: var(--spacing-md);
-    background: var(--bg-card);
-    border-radius: var(--radius-lg);
-    border: var(--border-subtle);
-    animation: slideUp 0.2s ease;
-}
-
-@keyframes slideUp {
-    from {
-        opacity: 0;
-        transform: translateY(8px);
-    }
-    to {
-        opacity: 1;
-        transform: translateY(0);
-    }
-}
-
-.day-detail.hidden {
-    display: none;
-}
-
-.day-detail-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: var(--spacing-md);
-    padding-bottom: var(--spacing-sm);
-    border-bottom: var(--border-subtle);
-}
-
-.day-detail-header h4 {
-    font-size: 1rem;
-    font-weight: 600;
-    color: var(--text-primary);
-}
-
-.day-detail-close {
+/* Day Detail - Compact tooltip */
+.day-detail-compact {
     display: flex;
     align-items: center;
     justify-content: center;
-    width: 32px;
-    height: 32px;
-    border: none;
-    border-radius: var(--radius-full);
-    background: var(--color-gray-100);
-    color: var(--text-secondary);
-    font-size: 1.25rem;
-    cursor: pointer;
-    transition: background-color 0.15s ease;
-}
-
-.day-detail-close:hover {
-    background: var(--color-gray-200);
-}
-
-.day-detail-content {
-    display: flex;
-    flex-direction: column;
     gap: var(--spacing-sm);
+    margin-top: var(--spacing-md);
+    padding: var(--spacing-sm) var(--spacing-md);
+    background: var(--bg-card);
+    border-radius: var(--radius-lg);
+    border: var(--border-subtle);
+    animation: fadeIn 0.15s ease;
 }
 
-.day-detail-score {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-sm);
-    padding: var(--spacing-sm);
-    background: var(--color-gray-50);
-    border-radius: var(--radius-md);
+@keyframes fadeIn {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
 }
 
-.day-detail-score__value {
-    font-size: 1.5rem;
-    font-weight: 700;
+.day-detail-compact.hidden {
+    display: none;
 }
 
-.day-detail-score__label {
+.day-detail-compact__date {
     font-size: 0.875rem;
     color: var(--text-secondary);
 }
 
-.day-detail-metrics {
-    display: grid;
-    grid-template-columns: repeat(2, 1fr);
-    gap: var(--spacing-xs);
-}
-
-.day-detail-metric {
-    display: flex;
-    align-items: center;
-    gap: var(--spacing-xs);
-    padding: var(--spacing-xs) var(--spacing-sm);
-    font-size: 0.875rem;
-    color: var(--text-secondary);
-}
-
-.day-detail-metric__icon {
+.day-detail-compact__score {
     font-size: 1rem;
-}
-
-.day-detail-empty {
-    text-align: center;
-    padding: var(--spacing-lg);
+    font-weight: 600;
     color: var(--text-muted);
 }
 
@@ -3257,14 +3151,7 @@ a:focus-visible,
         margin: 0 auto;
     }
 
-    .calendar-legend {
-        max-width: 500px;
-        margin-left: auto;
-        margin-right: auto;
-        margin-top: var(--spacing-lg);
-    }
-
-    .day-detail {
+    .day-detail-compact {
         max-width: 500px;
         margin-left: auto;
         margin-right: auto;


### PR DESCRIPTION
## Summary
Vereenvoudigt de kalender op basis van feedback:
- Legenda verwijderd
- Uitgebreid detail-paneel vervangen door compacte tooltip
- Alleen datum + score bij tap

## Changes
- `src/index.html` - Legenda en detail-paneel verwijderd
- `src/js/app.js` - showDayDetail vereenvoudigd
- `src/styles/main.css` - CSS opgeschoond

## Test plan
- [ ] Open Geschiedenis tab
- [ ] Tap op dag → toont "12 dec — 85%"
- [ ] Navigatie werkt nog

🤖 Generated with [Claude Code](https://claude.com/claude-code)