### PR TITLE
refactor: Simplify history view to dots-only grid

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -814,6 +814,7 @@
 
             <!-- History View - Dots Grid (minimal, no header) -->
             <section id="history-view" class="view">
+                <p class="dots-intro">Dagscore overzicht</p>
                 <div class="dots-grid-wrapper">
                     <div id="dots-timeline" class="dots-timeline">
                         <!-- Timeline markers will be rendered by JavaScript -->

--- a/src/index.html
+++ b/src/index.html
@@ -812,67 +812,20 @@
                 </div>
             </section>
 
-            <!-- History View - Calendar Overview -->
+            <!-- History View - Dots Grid (minimal, no header) -->
             <section id="history-view" class="view">
-                <h2>Geschiedenis</h2>
-
-                <!-- Calendar Navigation -->
-                <div class="calendar-nav">
-                    <button id="prev-month" class="calendar-nav-btn" aria-label="Vorige maand">
-                        <svg
-                            width="20"
-                            height="20"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            stroke-width="2"
-                        >
-                            <path d="M15 18l-6-6 6-6" />
-                        </svg>
-                    </button>
-                    <h3 id="calendar-month-year" class="calendar-title">december 2025</h3>
-                    <button id="next-month" class="calendar-nav-btn" aria-label="Volgende maand">
-                        <svg
-                            width="20"
-                            height="20"
-                            viewBox="0 0 24 24"
-                            fill="none"
-                            stroke="currentColor"
-                            stroke-width="2"
-                        >
-                            <path d="M9 18l6-6-6-6" />
-                        </svg>
-                    </button>
-                </div>
-
-                <!-- Calendar Grid -->
-                <div class="calendar-container">
-                    <!-- Weekday Headers -->
-                    <div class="calendar-weekdays">
-                        <span>ma</span>
-                        <span>di</span>
-                        <span>wo</span>
-                        <span>do</span>
-                        <span>vr</span>
-                        <span>za</span>
-                        <span>zo</span>
+                <div class="dots-grid-wrapper">
+                    <div id="dots-timeline" class="dots-timeline">
+                        <!-- Timeline markers will be rendered by JavaScript -->
                     </div>
-
-                    <!-- Calendar Days Grid -->
                     <div
                         id="calendar-grid"
-                        class="calendar-grid"
-                        role="grid"
-                        aria-label="Kalender met dagscores"
+                        class="dots-grid"
+                        role="img"
+                        aria-label="Score overzicht"
                     >
-                        <!-- Days will be rendered by JavaScript -->
+                        <!-- Dots will be rendered by JavaScript -->
                     </div>
-                </div>
-
-                <!-- Day Detail (compact tooltip, shown when tapping a day) -->
-                <div id="day-detail" class="day-detail-compact hidden">
-                    <span id="day-detail-date" class="day-detail-compact__date"></span>
-                    <span id="day-detail-score" class="day-detail-compact__score"></span>
                 </div>
             </section>
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3160,10 +3160,12 @@ a:focus-visible,
 }
 
 .dots-grid .dot {
-    width: 16px;
-    height: 16px;
+    width: 20px;
+    height: 20px;
     border-radius: 50%;
     flex-shrink: 0;
+    /* NOTE: Als dots interactief worden (doorklikken naar dag),
+       verhoog naar 44x44px voor WCAG touch target compliance */
 }
 
 .dots-grid .dots-empty {
@@ -3182,7 +3184,7 @@ a:focus-visible,
     }
 
     .dots-grid .dot {
-        width: 18px;
-        height: 18px;
+        width: 24px;
+        height: 24px;
     }
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3110,9 +3110,25 @@ a:focus-visible,
    DOTS GRID (HISTORY VIEW)
    ============================================ */
 
-/* History view - hide header */
+/* Hide app header and main content when history view is active */
+#history-view.active ~ .app-header-compact,
+.container:has(#history-view.active) .app-header-compact,
+.container:has(#history-view.active) #main-content,
+.container:has(#history-view.active) .score-message-compact {
+    display: none;
+}
+
+/* History view */
 #history-view {
-    padding-top: var(--spacing-md);
+    padding-top: var(--spacing-lg);
+}
+
+/* Intro text */
+.dots-intro {
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+    text-align: center;
+    margin-bottom: var(--spacing-sm);
 }
 
 /* Dots grid container with timeline */
@@ -3144,8 +3160,8 @@ a:focus-visible,
 }
 
 .dots-grid .dot {
-    width: 12px;
-    height: 12px;
+    width: 16px;
+    height: 16px;
     border-radius: 50%;
     flex-shrink: 0;
 }
@@ -3166,7 +3182,7 @@ a:focus-visible,
     }
 
     .dots-grid .dot {
-        width: 14px;
-        height: 14px;
+        width: 18px;
+        height: 18px;
     }
 }

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -3106,63 +3106,67 @@ a:focus-visible,
     background: var(--color-primary);
 }
 
-/* Day Detail - Compact tooltip */
-.day-detail-compact {
+/* ============================================
+   DOTS GRID (HISTORY VIEW)
+   ============================================ */
+
+/* History view - hide header */
+#history-view {
+    padding-top: var(--spacing-md);
+}
+
+/* Dots grid container with timeline */
+.dots-grid-wrapper {
     display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: var(--spacing-sm);
-    margin-top: var(--spacing-md);
-    padding: var(--spacing-sm) var(--spacing-md);
-    background: var(--bg-card);
-    border-radius: var(--radius-lg);
-    border: var(--border-subtle);
-    animation: fadeIn 0.15s ease;
+    gap: var(--spacing-md);
+    padding: var(--spacing-md);
 }
 
-@keyframes fadeIn {
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 1;
-    }
-}
-
-.day-detail-compact.hidden {
-    display: none;
-}
-
-.day-detail-compact__date {
-    font-size: 0.875rem;
-    color: var(--text-secondary);
-}
-
-.day-detail-compact__score {
-    font-size: 1rem;
-    font-weight: 600;
+/* Timeline on the left */
+.dots-timeline {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    font-size: 0.625rem;
     color: var(--text-muted);
+    min-width: 40px;
+    text-align: right;
+    padding: var(--spacing-xs) 0;
+}
+
+/* Dots grid */
+.dots-grid {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 4px;
+    align-content: flex-start;
+    padding: var(--spacing-md);
+}
+
+.dots-grid .dot {
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.dots-grid .dots-empty {
+    color: var(--text-muted);
+    font-size: 0.875rem;
+    text-align: center;
+    width: 100%;
+    padding: var(--spacing-xl);
 }
 
 /* Responsive: Larger screens */
 @media (min-width: 768px) {
-    .calendar-container {
-        max-width: 500px;
+    .dots-grid {
+        max-width: 400px;
         margin: 0 auto;
     }
 
-    .day-detail-compact {
-        max-width: 500px;
-        margin-left: auto;
-        margin-right: auto;
-    }
-
-    .calendar-day__number {
-        font-size: 1rem;
-    }
-
-    .calendar-day__dot {
-        width: 12px;
-        height: 12px;
+    .dots-grid .dot {
+        width: 14px;
+        height: 14px;
     }
 }


### PR DESCRIPTION
## Summary

- Remove all text, navigation, and calendar structure from history view
- Display only colored dots based on daily health scores
- Add minimal timeline showing date range (newest at top, oldest at bottom)
- Remove app header from history view

Follows user feedback requesting maximum simplification - just colored dots showing mood patterns at a glance.

Closes #73

## Test plan
- [x] Lint passes
- [x] 186 tests pass
- [x] Build succeeds
- [ ] Manual verification in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)